### PR TITLE
Bug fix

### DIFF
--- a/src/example.ts
+++ b/src/example.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as Web3 from 'web3';
 import * as BigNumber from 'bignumber.js';
-import DumbContract from "../contracts/DumbContract";
+import { DumbContract } from "../contracts/DumbContract";
 
 const dumbContractAddress = "0x00000000000";
 const accountAddress = "0x00000000000";


### PR DESCRIPTION
Building with webpack 3.5.5 throws: TS1192: Module '".../Typechain-example/contracts/DumbContract"' has no default export.